### PR TITLE
Run spice upgrade after homebrew spice cli is installed / upgraded

### DIFF
--- a/Formula/spice.rb
+++ b/Formula/spice.rb
@@ -28,7 +28,7 @@ class Spice < Formula
   end
 
   def install
-    ohai "Installing spice binary..."
+    ohai "Installing Spice CLI..."
     bin.install "spice" => "spice"
   end
 

--- a/Formula/spice.rb
+++ b/Formula/spice.rb
@@ -33,7 +33,7 @@ class Spice < Formula
   end
 
   def post_install
-    ohai "Upgrading spice runtime..."
+    ohai "Upgrading Spice Runtime..."
     output = Utils.safe_popen_read("sh", "-c", "#{bin}/spice upgrade 2>&1")
     output.lines.each do |line|
       puts line

--- a/Formula/spice.rb
+++ b/Formula/spice.rb
@@ -28,6 +28,15 @@ class Spice < Formula
   end
 
   def install
-      bin.install "spice" => "spice"
+    ohai "Installing spice binary..."
+    bin.install "spice" => "spice"
+  end
+
+  def post_install
+    ohai "Upgrading spice runtime..."
+    output = Utils.safe_popen_read("sh", "-c", "#{bin}/spice upgrade 2>&1")
+    output.lines.each do |line|
+      puts line
+    end
   end
 end


### PR DESCRIPTION
## 🗣 Description

In homebrew spice formula, run `spice upgrade` after the homebrew spice cli is installed / upgraded. This ensures the homebrew spice upgrade will automatically upgrade the runtime as well.

- Upgrade
```bash
brew upgrade spiceai/spiceai/spice
==> Upgrading 1 outdated package:
spiceai/spiceai/spice v1.0.2_1 -> v1.0.3_1
==> Fetching spiceai/spiceai/spice
==> Downloading https://github.com/spiceai/spiceai/releases/download/v1.0.3/spice_darwin_aarch64.tar.gz
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/394089041/88109b29-c4d8-4a66-8e96-c2c225aea78e?X
########################################################################################################################################### 100.0%
==> Upgrading spiceai/spiceai/spice
  v1.0.2_1 -> v1.0.3_1 
==> Installing spice binary...
==> Upgrading spice runtime...
2025/02/13 14:40:50 INFO Checking for latest Spice CLI release...
2025/02/13 14:40:51 INFO Using the latest version v1.0.3. No upgrade required.
2025/02/13 14:40:51 INFO Checking for the latest Spice Runtime release...
2025/02/13 14:40:51 INFO Using version v1.1.0. No upgrade required.
🍺  /opt/homebrew/Cellar/spice/v1.0.3_1: 4 files, 16.0MB, built in 2 seconds
==> Running `brew cleanup spice`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Removing: /opt/homebrew/Cellar/spice/v1.0.2_1... (4 files, 16.0MB)
Removing: /Users/qianqian/Library/Caches/Homebrew/spice--v1.0.3.tar.gz... (8.3MB)
```

- Install
```bash
==> Auto-updating Homebrew...
Adjust how often this is run with HOMEBREW_AUTO_UPDATE_SECS or disable with
HOMEBREW_NO_AUTO_UPDATE. Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
==> Auto-updated Homebrew!
Updated 2 taps (supabase/tap and homebrew/core).
==> New Formulae
go@1.23                                                                   reuse

You have 42 outdated formulae and 1 outdated cask installed.

==> Fetching spiceai/spiceai/spice
==> Downloading https://github.com/spiceai/spiceai/releases/download/v1.0.3/spice_darwin_aarch64.tar.gz
==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/394089041/88109b29-c4d8-4a66-8e96-c2c225aea78e?X
########################################################################################################################################### 100.0%
==> Installing spice from spiceai/spiceai
==> Installing spice binary...
==> Upgrading spice runtime...
2025/02/13 14:38:50 INFO Checking for latest Spice CLI release...
2025/02/13 14:38:50 INFO Using the latest version v1.0.3. No upgrade required.
2025/02/13 14:38:50 INFO Checking for the latest Spice Runtime release...
2025/02/13 14:38:50 INFO Using version v1.1.0. No upgrade required.
🍺  /opt/homebrew/Cellar/spice/v1.0.3_1: 4 files, 16.0MB, built in 2 seconds
==> Running `brew cleanup spice`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Removing: /Users/qianqian/Library/Caches/Homebrew/spice--v1.0.3.tar.gz... (8.3MB)
```

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

I will need to update some logic in spice upgrade to only block the cli upgrade but not runtime upgrade for the homebrew Spice CLI. I will also add a e2e test mimicking the homebrew spice cli behavior.
