### PR TITLE
Serve all supported OS architectures & Shows docs link if user OS arch is unsupported

### DIFF
--- a/Formula/spice.rb
+++ b/Formula/spice.rb
@@ -1,8 +1,7 @@
-$pkg     = "github.com/spiceai/spiceai"
-$tags    = %w()
+$pkg = "github.com/spiceai/spiceai"
 $darwin_aarch64_sha256 = "eebdbee4f7f7f41466c87bab924ac81d0cc0dced8ee46afad1394ff01b0abcd7"
-$darwin_x86_64_sha256 = "2537b42b9c1fc2b436380ea12539bfdec4d7695aeaf27735709b915cd11d3291"
 $linux_x86_64_sha256 = "b6b6d5820afe4b245439713f03480a5b73f2ca60bac67b0b2606d2c5f221e2ed"
+$linux_aarch64_sha256 = "f7813ee61955f191801dc96959c488b1bb27e40a4bae6bd32e572c9bb58af357"
 
 class Spice < Formula
   desc "Spice.ai CLI"
@@ -11,19 +10,27 @@ class Spice < Formula
   version "v1.0.3"
   revision 1
 
-  if OS.mac?
+  BASE_URL = "https://#{$pkg}/releases/download/#{version}"
+  ERROR_MSG = "Unfortunately, your OS architecture is not supported. For supported architectures, please visit spiceai.org/docs/installation#supported-os-architectures"
+
+  on_macos do
     if Hardware::CPU.arm?
-        url "https://github.com/spiceai/spiceai/releases/download/#{version}/spice_darwin_aarch64.tar.gz"
-        sha256 $darwin_aarch64_sha256
+      url "#{BASE_URL}/spice_darwin_aarch64.tar.gz"
+      sha256 $darwin_aarch64_sha256
     else
-        url "https://github.com/spiceai/spiceai/releases/download/#{version}/spice_darwin_x86_64.tar.gz"
-        sha256 $darwin_x86_64_sha256
+      odie ERROR_MSG
     end
-  elsif OS.linux?
+  end
+
+  on_linux do
     if Hardware::CPU.arm?
+      url "#{BASE_URL}/spice_linux_aarch64.tar.gz"
+      sha256 $linux_aarch64_sha256
+    elsif Hardware::CPU.intel?
+      url "#{BASE_URL}/spice_linux_x86_64.tar.gz"
+      sha256 $linux_x86_64_sha256
     else
-        url "https://github.com/spiceai/spiceai/releases/download/#{version}/spice_linux_x86_64.tar.gz"
-        sha256 $linux_x86_64_sha256
+      odie ERROR_MSG
     end
   end
 

--- a/Formula/spice.rb
+++ b/Formula/spice.rb
@@ -10,8 +10,19 @@ class Spice < Formula
   version "v1.0.4"
   revision 1
 
+  os = `uname`.strip.downcase
+  arch = `uname -m`.strip
+
+  case arch
+  when /armv7.*/ then arch = "arm"
+  when "arm64" then arch = "aarch64"
+  when "amd64" then arch = "x86_64"
+  end
+
+  current_osarch = "#{os}-#{arch}"
+
   BASE_URL = "https://#{$pkg}/releases/download/#{version}"
-  ERROR_MSG = "Your OS architecture does not have a pre-built binary. For supported architectures, visit https://spiceai.org/docs/installation#supported-os-architectures"
+  ERROR_MSG = "#{current_osarch} does not have a pre-built binary. For supported architectures, visit https://spiceai.org/docs/reference/system_requirements#operating-systems-and-architectures"
 
   on_macos do
     if Hardware::CPU.arm?

--- a/Formula/spice.rb
+++ b/Formula/spice.rb
@@ -11,7 +11,7 @@ class Spice < Formula
   revision 1
 
   BASE_URL = "https://#{$pkg}/releases/download/#{version}"
-  ERROR_MSG = "Unfortunately, your OS architecture is not supported. For supported architectures, please visit spiceai.org/docs/installation#supported-os-architectures"
+  ERROR_MSG = "Your OS architecture does not have a pre-built binary. For supported architectures, visit https://spiceai.org/docs/installation#supported-os-architectures"
 
   on_macos do
     if Hardware::CPU.arm?

--- a/Formula/spiced.rb
+++ b/Formula/spiced.rb
@@ -11,7 +11,7 @@ class Spiced < Formula
   revision 1
 
   BASE_URL = "https://#{$pkg}/releases/download/#{version}"
-  ERROR_MSG = "Unfortunately, your OS architecture is not supported. For supported architectures, please visit spiceai.org/docs/installation#supported-os-architectures"
+  ERROR_MSG = "Your OS architecture does not have a pre-built binary. For supported architectures, visit https://spiceai.org/docs/installation#supported-os-architectures"
 
   on_macos do
     if Hardware::CPU.arm?

--- a/Formula/spiced.rb
+++ b/Formula/spiced.rb
@@ -10,8 +10,19 @@ class Spiced < Formula
   version "v1.0.4"
   revision 1
 
+  os = `uname`.strip.downcase
+  arch = `uname -m`.strip
+
+  case arch
+  when /armv7.*/ then arch = "arm"
+  when "arm64" then arch = "aarch64"
+  when "amd64" then arch = "x86_64"
+  end
+
+  current_osarch = "#{os}-#{arch}"
+
   BASE_URL = "https://#{$pkg}/releases/download/#{version}"
-  ERROR_MSG = "Your OS architecture does not have a pre-built binary. For supported architectures, visit https://spiceai.org/docs/installation#supported-os-architectures"
+  ERROR_MSG = "#{current_osarch} does not have a pre-built binary. For supported architectures, visit https://spiceai.org/docs/reference/system_requirements#operating-systems-and-architectures"
 
   on_macos do
     if Hardware::CPU.arm?

--- a/Formula/spiced.rb
+++ b/Formula/spiced.rb
@@ -1,8 +1,7 @@
-$pkg     = "github.com/spiceai/spiceai"
-$tags    = %w()
+$pkg = "github.com/spiceai/spiceai"
 $darwin_aarch64_sha256 = "a6b3a8c8e47170bf52a30d2d99a196ec608693dae3d5d2e1d72a051ddebd555e"
-$darwin_x86_64_sha256 = "acd2268c5df56ee7a601bbc4c5670d34a6c8dea3731f17183351458d56c3575b"
 $linux_x86_64_sha256 = "2bac91c0c9f415bc40a97443f30e1c649db909a26f592ce3b467bc78c4a3dc0f"
+$linux_aarch64_sha256 = "96c2ae65e32663a3aa7aee13e86abf99f2491e3eaae0c865a01205e5a8c47951"
 
 class Spiced < Formula
   desc "A unified SQL query interface and portable runtime to locally materialize, accelerate, and query data tables sourced from any database, data warehouse, or data lake."
@@ -11,19 +10,27 @@ class Spiced < Formula
   version "v1.0.3"
   revision 1
 
-  if OS.mac?
+  BASE_URL = "https://#{$pkg}/releases/download/#{version}"
+  ERROR_MSG = "Unfortunately, your OS architecture is not supported. For supported architectures, please visit spiceai.org/docs/installation#supported-os-architectures"
+
+  on_macos do
     if Hardware::CPU.arm?
-        url "https://github.com/spiceai/spiceai/releases/download/#{version}/spiced_darwin_aarch64.tar.gz"
-        sha256 $darwin_aarch64_sha256
+      url "#{BASE_URL}/spice_darwin_aarch64.tar.gz"
+      sha256 $darwin_aarch64_sha256
     else
-        url "https://github.com/spiceai/spiceai/releases/download/#{version}/spiced_darwin_x86_64.tar.gz"
-        sha256 $darwin_x86_64_sha256
+      odie ERROR_MSG
     end
-  elsif OS.linux?
+  end
+
+  on_linux do
     if Hardware::CPU.arm?
+      url "#{BASE_URL}/spice_linux_aarch64.tar.gz"
+      sha256 $linux_aarch64_sha256
+    elsif Hardware::CPU.intel?
+      url "#{BASE_URL}/spice_linux_x86_64.tar.gz"
+      sha256 $linux_x86_64_sha256
     else
-        url "https://github.com/spiceai/spiceai/releases/download/#{version}/spiced_linux_x86_64.tar.gz"
-        sha256 $linux_x86_64_sha256
+      odie ERROR_MSG
     end
   end
 

--- a/update-version
+++ b/update-version
@@ -21,7 +21,7 @@ for i in spice spiced; do
 done
 
 for i in spice spiced; do
-  for j in darwin_aarch64 linux_x86_64; do
+  for j in darwin_aarch64 linux_x86_64 linux_aarch64; do
     wget https://github.com/spiceai/spiceai/releases/download/$version/${i}_${j}.tar.gz
     sha=$(sha256sum ${i}_${j}.tar.gz | cut -d " " -f 1)
 


### PR DESCRIPTION
## 🗣 Description
* Add omitted linux-aarch64 : linux-aarch64 has not been served in brew, even if it has been actually supported.
* Return error message which shows the url for supported OS list, if user OS arch is not supported.

## 🔨 Related Issues

[#4780](https://github.com/spiceai/spiceai/issues/4780)

## 🤔 Concerns

1. This PR should be applied after the website is deployed (https://github.com/spiceai/docs/pull/878), to make the url (in error msg) valid.
(cf. even if the website is not updated, the url itself makes user land to spiceai.org/docs/installation anyway)

2. If you want to change the error message, please feel free to modify it.